### PR TITLE
Reduce re-renders

### DIFF
--- a/src/components/Books/Book.js
+++ b/src/components/Books/Book.js
@@ -18,11 +18,11 @@ export const Book = ({ book, setBooks }) => {
     const deleteBook = (bookId) => {
         if (book.current === true) {
             BookRepo.delete(bookId)
-                .then(() => BookRepo.getAll(true)
+                .then(() => BookRepo.getAll("True")
                     .then(setBooks))
         } else {
             BookRepo.delete(bookId)
-                .then(() => BookRepo.getAll(false)
+                .then(() => BookRepo.getAll("False")
                     .then(setBooks))
         }
     }

--- a/src/components/Books/BookQueueView.js
+++ b/src/components/Books/BookQueueView.js
@@ -41,7 +41,8 @@ export const BookQueueView = () => {
                 setAttemptBoolean(false)
             }
 
-            BookRepo.getAll(filters.current, filters.nameSearch, filters.authorId, filters.tagArray)
+            setLoading(true)
+            BookRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.authorId)
                 .then(setBooks)
                 .then(() => setLoading(false))
 

--- a/src/components/Books/BookQueueView.js
+++ b/src/components/Books/BookQueueView.js
@@ -41,8 +41,7 @@ export const BookQueueView = () => {
                 setAttemptBoolean(false)
             }
 
-            setLoading(true)
-            BookRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.authorId)
+            BookRepo.getAll(filters.current, filters.tagArray, filters.nameSearch, filters.authorId)
                 .then(setBooks)
                 .then(() => setLoading(false))
 

--- a/src/components/Books/CurrentBooksView.js
+++ b/src/components/Books/CurrentBooksView.js
@@ -41,8 +41,7 @@ export const CurrentBooksView = () => {
                 setAttemptBoolean(false)
             }
 
-            setLoading(true)
-            BookRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.authorId)
+            BookRepo.getAll(filters.current, filters.tagArray, filters.nameSearch, filters.authorId)
                 .then(setBooks)
                 .then(() => setLoading(false))
 

--- a/src/components/Books/CurrentBooksView.js
+++ b/src/components/Books/CurrentBooksView.js
@@ -41,7 +41,8 @@ export const CurrentBooksView = () => {
                 setAttemptBoolean(false)
             }
 
-            BookRepo.getAll(filters.current, filters.nameSearch, filters.authorId, filters.tagArray)
+            setLoading(true)
+            BookRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.authorId)
                 .then(setBooks)
                 .then(() => setLoading(false))
 

--- a/src/components/Books/SearchBooks.js
+++ b/src/components/Books/SearchBooks.js
@@ -3,14 +3,16 @@ import { Button, Form, FormGroup, Input, Label } from "reactstrap"
 import { BookRepo } from "../../repositories/BookRepo"
 import { TagRepo } from "../../repositories/TagRepo"
 
-export const SearchBooks = ({ userEntries, setUserEntries, taggedBooks }) => {
+export const SearchBooks = ({ userEntries, setUserEntries }) => {
     const [tags, setTags] = useState([])
     const [authors, setAuthors] = useState([])
+    const [isLoading, setLoading] = useState(true)
 
     useEffect(
         () => {
             TagRepo.getTagsOnBooks().then(setTags)
-            BookRepo.getAllAuthors().then(setAuthors)
+                .then(() => BookRepo.getAllAuthors().then(setAuthors))
+                .then(() => setLoading(false))
         }, []
     )
 
@@ -24,96 +26,102 @@ export const SearchBooks = ({ userEntries, setUserEntries, taggedBooks }) => {
     }
 
     return (
-        <Form className="pb-2 mt-5 px-3 bg-secondary shadow-sm rounded text-white" inline>
+        <>
+            {
+                isLoading
+                    ? <div className="pb-2 mt-5 px-3" ></div>
+                    : <Form className="pb-2 mt-5 px-3 bg-secondary shadow-sm rounded text-white" inline>
 
-            <h5 className="text-center py-3">Filters</h5>
+                        <h5 className="text-center py-3">Filters</h5>
 
-            <FormGroup>
-                <Label for="nameSearch">
-                    Search by Title
-                </Label>
-                <Input
-                    id="nameSearch"
-                    type="search"
-                    placeholder="Title contains..."
-                    value={userEntries.name}
-                    onChange={(event) => {
-                        const userEntriesCopy = { ...userEntries }
-                        userEntriesCopy.name = event.target.value
-                        setUserEntries(userEntriesCopy)
-                    }}
-                />
-            </FormGroup>
-            <FormGroup>
-                <Label for="authorSelect">
-                    Author
-                </Label>
-                <Input
-                    id="authorSelect"
-                    name="select"
-                    type="select"
-                    value={userEntries.author}
-                    onChange={(event) => {
-                        const userEntriesCopy = { ...userEntries }
-                        userEntriesCopy.author = event.target.value
-                        setUserEntries(userEntriesCopy)
-                    }}
-                >
-                    <option value="0"> Select one... </option>
-                    {
-                        authors.map(author => {
-                            return <option key={author.id} value={author.id}>{author.name}</option>
-                        })
-                    }
+                        <FormGroup>
+                            <Label for="nameSearch">
+                                Search by Title
+                            </Label>
+                            <Input
+                                id="nameSearch"
+                                type="search"
+                                placeholder="Title contains..."
+                                value={userEntries.name}
+                                onChange={(event) => {
+                                    const userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy.name = event.target.value
+                                    setUserEntries(userEntriesCopy)
+                                }}
+                            />
+                        </FormGroup>
+                        <FormGroup>
+                            <Label for="authorSelect">
+                                Author
+                            </Label>
+                            <Input
+                                id="authorSelect"
+                                name="select"
+                                type="select"
+                                value={userEntries.author}
+                                onChange={(event) => {
+                                    const userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy.author = event.target.value
+                                    setUserEntries(userEntriesCopy)
+                                }}
+                            >
+                                <option value="0"> Select one... </option>
+                                {
+                                    authors.map(author => {
+                                        return <option key={author.id} value={author.id}>{author.name}</option>
+                                    })
+                                }
 
-                </Input>
-            </FormGroup>
-            <FormGroup>
-                <Label>
-                    Tags
-                </Label>
-                <div>
-                    {
-                        tags.length > 0
-                            ? tags.map(tag => {
-                                return <Button
-                                    key={`tag--${tag.id}`}
-                                    active={userEntries.tags.has(tag.id) ? true : false}
-                                    color="checkbox"
-                                    style={{ borderRadius: '20px' }}
-                                    outline
-                                    size="sm"
-                                    className="mx-1 my-2 text-white"
-                                    onClick={() => setTag(tag.id)}
-                                >
-                                    {tag.tag}
-                                </Button>
+                            </Input>
+                        </FormGroup>
+                        <FormGroup>
+                            <Label>
+                                Tags
+                            </Label>
+                            <div>
+                                {
+                                    tags.length > 0
+                                        ? tags.map(tag => {
+                                            return <Button
+                                                key={`tag--${tag.id}`}
+                                                active={userEntries.tags.has(tag.id) ? true : false}
+                                                color="checkbox"
+                                                style={{ borderRadius: '20px' }}
+                                                outline
+                                                size="sm"
+                                                className="mx-1 my-2 text-white"
+                                                onClick={() => setTag(tag.id)}
+                                            >
+                                                {tag.tag}
+                                            </Button>
 
 
-                            })
-                            : ""
-                    }
-                </div>
-            </FormGroup>
-            <FormGroup className='row justify-content-center'>
-                <Button
-                    onClick={() => {
-                        let userEntriesCopy = { ...userEntries }
-                        userEntriesCopy = {
-                            name: "",
-                            author: "0",
-                            tags: new Set()
-                        }
-                        setUserEntries(userEntriesCopy)
-                    }
-                    }
-                    size="sm"
-                    color="info"
-                    className="col-sm-9 col-md-7 col-lg-5 mt-2"
-                >
-                    Clear Filters
-                </Button>
-            </FormGroup>
-        </Form>
+                                        })
+                                        : ""
+                                }
+                            </div>
+                        </FormGroup>
+                        <FormGroup className='row justify-content-center'>
+                            <Button
+                                onClick={() => {
+                                    let userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy = {
+                                        name: "",
+                                        author: "0",
+                                        tags: new Set()
+                                    }
+                                    setUserEntries(userEntriesCopy)
+                                }
+                                }
+                                size="sm"
+                                color="info"
+                                className="col-sm-9 col-md-7 col-lg-5 mt-2"
+                            >
+                                Clear Filters
+                            </Button>
+                        </FormGroup>
+                    </Form>
+            }
+        </>
     )
 }

--- a/src/components/HomePage/FilterForm.js
+++ b/src/components/HomePage/FilterForm.js
@@ -48,6 +48,27 @@ export const FilterForm = ({ userEntries, setUserEntries }) => {
                             />
                         </FormGroup>
                         <FormGroup>
+                            <Label for="currentSelect">
+                                Current or Queued?
+                            </Label>
+                            <Input
+                                id="currentSelect"
+                                name="select"
+                                type="select"
+                                value={userEntries.current}
+                                onChange={(event) => {
+                                    const copy = { ...userEntries }
+                                    copy.current = event.target.value
+                                    setUserEntries(copy)
+                                }}
+                            >
+                                <option value=""> Select one... </option>
+                                <option value="True"> Current </option>
+                                <option value="False"> Queued </option>
+
+                            </Input>
+                        </FormGroup>
+                        <FormGroup>
                             <Label>
                                 Tags
                             </Label>
@@ -77,7 +98,8 @@ export const FilterForm = ({ userEntries, setUserEntries }) => {
                                 onClick={() => {
                                     const reset = {
                                         title: "",
-                                        tags: new Set()
+                                        tags: new Set(),
+                                        current: ""
                                     }
                                     setUserEntries(reset)
                                 }

--- a/src/components/HomePage/FilterForm.js
+++ b/src/components/HomePage/FilterForm.js
@@ -4,10 +4,12 @@ import { TagRepo } from "../../repositories/TagRepo"
 
 export const FilterForm = ({ userEntries, setUserEntries }) => {
     const [tags, setTags] = useState([])
+    const [isLoading, setIsLoading] = useState(true)
 
     useEffect(
         () => {
             TagRepo.getTagsOnAny().then(setTags)
+                .then(() => setIsLoading(false))
         }, []
     )
 
@@ -22,69 +24,73 @@ export const FilterForm = ({ userEntries, setUserEntries }) => {
 
     return (
         <div className="col-3 text-white">
-            <Form className="pb-2 mt-5 px-3 bg-secondary shadow-sm" style={{borderRadius: 20}}inline>
+            {
+                isLoading
+                    ? ""
+                    : <Form className="pb-2 mt-5 px-3 bg-secondary shadow-sm" style={{ borderRadius: 20 }} inline>
 
-                <h5 className="text-center pt-5 pb-4">Filters</h5>
+                        <h5 className="text-center pt-5 pb-4">Filters</h5>
 
-                <FormGroup>
-                    <Label for="titleSearch">
-                        Search by Title
-                    </Label>
-                    <Input
-                        id="titleSearch"
-                        type="search"
-                        placeholder="Title contains..."
-                        value={userEntries.title}
-                        onChange={(event) => {
-                            const userEntriesCopy = { ...userEntries }
-                            userEntriesCopy.title = event.target.value
-                            setUserEntries(userEntriesCopy)
-                        }}
-                    />
-                </FormGroup>
-                <FormGroup>
-                    <Label>
-                        Tags
-                    </Label>
-                    <div className="d-flex flex-row flex-wrap justify-content-start">
-                        {
-                            tags.length > 0
-                                ? tags.map(tag => {
-                                    return <Button
-                                        key={`tag--${tag.id}`}
-                                        active={userEntries.tags.has(tag.id) ? true : false}
-                                        color="checkbox"
-                                        style={{ borderRadius: '20px', fontWeight: 500 }}
-                                        outline
-                                        size="sm"
-                                        className= "mx-1 my-2 text-truncate text-white"
-                                        onClick={() => setTag(tag.id)}
-                                    >
-                                        {tag.tag}
-                                    </Button>
-                                })
-                                : ""
-                        }
-                    </div>
-                </FormGroup>
-                <FormGroup className='row justify-content-center'>
-                    <Button
-                        onClick={() => {
-                            const reset = {
-                                title: "",
-                                tags: new Set()
-                            }
-                            setUserEntries(reset)
-                        }
-                        }
-                        color="info"
-                        size="sm"
-                        className="col-sm-11 col-md-9 col-lg-7 col-xl-5 mt-2"
-                    >
-                        Clear Filters
-                    </Button>
-                </FormGroup>
-            </Form>
+                        <FormGroup>
+                            <Label for="titleSearch">
+                                Search by Title
+                            </Label>
+                            <Input
+                                id="titleSearch"
+                                type="search"
+                                placeholder="Title contains..."
+                                value={userEntries.title}
+                                onChange={(event) => {
+                                    const userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy.title = event.target.value
+                                    setUserEntries(userEntriesCopy)
+                                }}
+                            />
+                        </FormGroup>
+                        <FormGroup>
+                            <Label>
+                                Tags
+                            </Label>
+                            <div className="d-flex flex-row flex-wrap justify-content-start">
+                                {
+                                    tags.length > 0
+                                        ? tags.map(tag => {
+                                            return <Button
+                                                key={`tag--${tag.id}`}
+                                                active={userEntries.tags.has(tag.id) ? true : false}
+                                                color="checkbox"
+                                                style={{ borderRadius: '20px', fontWeight: 500 }}
+                                                outline
+                                                size="sm"
+                                                className="mx-1 my-2 text-truncate text-white"
+                                                onClick={() => setTag(tag.id)}
+                                            >
+                                                {tag.tag}
+                                            </Button>
+                                        })
+                                        : ""
+                                }
+                            </div>
+                        </FormGroup>
+                        <FormGroup className='row justify-content-center'>
+                            <Button
+                                onClick={() => {
+                                    const reset = {
+                                        title: "",
+                                        tags: new Set()
+                                    }
+                                    setUserEntries(reset)
+                                }
+                                }
+                                color="info"
+                                size="sm"
+                                className="col-sm-11 col-md-9 col-lg-7 col-xl-5 mt-2"
+                            >
+                                Clear Filters
+                            </Button>
+                        </FormGroup>
+                    </Form>
+            }
         </div>
     )
 }

--- a/src/components/HomePage/HomePage.js
+++ b/src/components/HomePage/HomePage.js
@@ -11,9 +11,12 @@ export const HomePage = () => {
     const [shows, setShows] = useState([])
     const [userAttemptedSearch, setAttemptBoolean] = useState(false)
     const [isLoading, setIsLoading] = useState(true)
-    const [loadingList, setLoadingList] = useState(false)
+    const [loadingGames, setLoadingGames] = useState(true)
+    const [loadingShows, setLoadingShows] = useState(true)
+    const [loadingBooks, setLoadingBooks] = useState(true)
     const [userEntries, setUserEntries] = useState({
         title: "",
+        current: "",
         tags: new Set()
     })
 
@@ -22,6 +25,7 @@ export const HomePage = () => {
         () => {
             const tagsExist = userEntries.tags.size > 0
             const titleExists = userEntries.title !== ""
+            const currentExists = userEntries.current !== ""
 
             let filters = {
                 title: "",
@@ -29,28 +33,29 @@ export const HomePage = () => {
                 tagArray: null
             }
 
-            if (titleExists) filters.titleSearch = userEntries.title
+            if (titleExists) filters.title = userEntries.title
+            if (currentExists) filters.current = userEntries.current
             if (tagsExist) filters.tagArray = Array.from(userEntries.tags)
 
             let promiseArray = []
 
-            promiseArray.push(GameRepo.getAll(filters.tagArray, filters.titleSearch, filters.current).then(setGames))
-            promiseArray.push(ShowRepo.getAll(filters.tagArray, filters.titleSearch, filters.current).then(setShows))
-            promiseArray.push(BookRepo.getAll(filters.tagArray, filters.titleSearch, filters.current).then(setBooks))
+            promiseArray.push(
+                GameRepo.getAll(filters.current, filters.tagArray, filters.title).then(setGames).then(() => setLoadingGames(false)))
+            promiseArray.push(
+                ShowRepo.getAll(filters.current, filters.tagArray, filters.title).then(setShows).then(() => setLoadingShows(false)))
+            promiseArray.push(
+                BookRepo.getAll(filters.current, filters.tagArray, filters.title).then(setBooks).then(() => setLoadingBooks(false)))
 
-            // setLoadingList(true)
 
             Promise.all(promiseArray)
                 .then(() => setIsLoading(false))
-                // .then(() => setLoadingList(false))
-                
+
             //mark whether a user has used the filters in order to determine the message they get for a blank list
             if (titleExists || tagsExist) {
                 setAttemptBoolean(true)
             } else {
                 setAttemptBoolean(false)
             }
-
 
         }, [userEntries]
     )
@@ -74,12 +79,10 @@ export const HomePage = () => {
                             {/* <div className="row justify-content-center mt-4"><h2 className='col-6 text-center'>Your Media</h2></div> */}
                             <div className="row justify-content-evenly">
                                 <FilterForm userEntries={userEntries} setUserEntries={setUserEntries} />
-                                {
-                                    loadingList
-                                        ? <div className="col-7"></div>
-                                        : <SearchResults games={games} books={books} 
-                                            shows={shows} userAttemptedSearch={userAttemptedSearch} />
-                                }
+                                <SearchResults games={games} books={books} shows={shows} 
+                                userAttemptedSearch={userAttemptedSearch} loadingBooks={loadingBooks} 
+                                loadingGames={loadingGames} loadingShows={loadingShows}/>
+
                             </div>
                         </div>
                     </>

--- a/src/components/HomePage/SearchResults.js
+++ b/src/components/HomePage/SearchResults.js
@@ -1,99 +1,26 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 import { Game } from "../VideoGames/Game"
 import { Show } from "../TVShows/Show"
 import { Book } from "../Books/Book"
 
-export const SearchResults = ({ games, shows, books, userAttemptedSearch }) => {
-    const [currentGames, setCurrentGames] = useState([])
-    const [queuedGames, setQueuedGames] = useState([])
-    const [currentShows, setCurrentShows] = useState([])
-    const [queuedShows, setQueuedShows] = useState([])
-    const [currentBooks, setCurrentBooks] = useState([])
-    const [queuedBooks, setQueuedBooks] = useState([])
-
-    useEffect(
-        () => {
-            setCurrentGames(games.filter(game => game.current === true))
-            setQueuedGames(games.filter(game => game.current === false))
-            setCurrentShows(shows.filter(show => show.current === true))
-            setQueuedShows(shows.filter(show => show.current === false))
-            setCurrentBooks(books.filter(book => book.current === true))
-            setQueuedBooks(books.filter(book => book.current === false))
-        },
-        [games, shows, books]
-    )
-
+export const SearchResults = ({ games, books, shows, userAttemptedSearch }) => {
     return (
 
         <article className="col-7">
             {
-                games.length > 0 || shows.length > 0 || books.length > 0
+                books.length > 0 || games.length > 0 || shows.length > 0
                     ?
                     <>
-                        <div>
-                            {
-                                currentGames.length > 0
-                                    ?
-                                    <>
-                                        <h3 className="mt-5 ">Current Games</h3>
-                                        <div>{currentGames.map(game => <Game key={game.id} game={game} />)}</div>
-                                    </>
-                                    : ""
-                            }
-                            {
-                                queuedGames.length > 0
-                                    ?
-                                    <>
-                                        <h3 className="mt-5 ">Queued Games</h3>
-                                        <div>{queuedGames.map(game => <Game key={game.id} game={game} />)}</div>
-                                    </>
-                                    : ""
-                            }
-                        </div>
-                        <div>
-                            {
-                                currentShows.length > 0
-                                    ?
-                                    <>
-                                        <h3 className="mt-5 ">Current Shows</h3>
-                                        <div>{currentShows.map(show => <Show key={show.id} show={show} />)}</div>
-                                    </>
-                                    : ""
-                            }
-                            {
-                                queuedShows.length > 0
-                                    ?
-                                    <>
-                                        <h3 className="mt-5 ">Queued Shows</h3>
-                                        <div>{queuedShows.map(show => <Show key={show.id} show={show} />)}</div>
-                                    </>
-                                    : ""
-                            }
-                        </div>
-                        <div>
-                            {
-                                currentBooks.length > 0
-                                    ?
-                                    <>
-                                        <h3 className="mt-5 ">Current Books</h3>
-                                        <div>{currentBooks.map(book => <Book key={book.id} book={book} />)}</div>
-                                    </>
-                                    : ""
-                            }
-                            {
-                                queuedBooks.length > 0
-                                    ?
-                                    <>
-                                        <h3 className="mt-5 ">Queued Books</h3>
-                                        <div>{queuedBooks.map(book => <Book key={book.id} book={book} />)}</div>
-                                    </>
-                                    : ""
-                            }
-                        </div>
+                        {games.length > 0 ? <h3 className="mt-5 ">Games</h3> : ""}
+                        <div>{games.map(game => <Game key={game.id} game={game} />)}</div>
+
+                        {shows.length > 0 ? <h3 className="mt-5 ">Shows</h3> : ""}
+                        <div>{shows.map(show => <Show key={show.id} show={show} />)}</div>
+
+                        {books.length > 0 ? <h3 className="mt-5 ">Books</h3> : ""}
+                        <div>{books.map(book => <Book key={book.id} book={book} />)}</div>
                     </>
-                    : <div
-                    className="mt-5 pt-5 border-0 d-flex align-items-center justify-content-center"
-                >
+                    : <div className="mt-5 pt-5 border-0 d-flex align-items-center justify-content-center">
                         <h5 className=" pt-5 mt-5 text-center text-muted">
                             {
                                 userAttemptedSearch
@@ -101,7 +28,7 @@ export const SearchResults = ({ games, shows, books, userAttemptedSearch }) => {
                                     : "Your list is empty. Select 'Create New' under a media type in the navbar to add items."
                             }
                         </h5>
-                </div>
+                    </div>
             }
 
         </article>

--- a/src/components/HomePage/SearchResults.js
+++ b/src/components/HomePage/SearchResults.js
@@ -3,7 +3,7 @@ import { Game } from "../VideoGames/Game"
 import { Show } from "../TVShows/Show"
 import { Book } from "../Books/Book"
 
-export const SearchResults = ({ games, books, shows, userAttemptedSearch }) => {
+export const SearchResults = ({ games, books, shows, userAttemptedSearch, loadingGames, loadingShows, loadingBooks }) => {
     return (
 
         <article className="col-7">
@@ -12,13 +12,13 @@ export const SearchResults = ({ games, books, shows, userAttemptedSearch }) => {
                     ?
                     <>
                         {games.length > 0 ? <h3 className="mt-5 ">Games</h3> : ""}
-                        <div>{games.map(game => <Game key={game.id} game={game} />)}</div>
+                        {loadingGames? "" : <div>{games.map(game => <Game key={game.id} game={game} />)}</div>}
 
                         {shows.length > 0 ? <h3 className="mt-5 ">Shows</h3> : ""}
-                        <div>{shows.map(show => <Show key={show.id} show={show} />)}</div>
+                        {loadingShows? "" : <div>{shows.map(show => <Show key={show.id} show={show} />)}</div>}
 
                         {books.length > 0 ? <h3 className="mt-5 ">Books</h3> : ""}
-                        <div>{books.map(book => <Book key={book.id} book={book} />)}</div>
+                        {loadingBooks? "" : <div>{books.map(book => <Book key={book.id} book={book} />)}</div>}
                     </>
                     : <div className="mt-5 pt-5 border-0 d-flex align-items-center justify-content-center">
                         <h5 className=" pt-5 mt-5 text-center text-muted">

--- a/src/components/Social/RecommendationList.js
+++ b/src/components/Social/RecommendationList.js
@@ -8,41 +8,49 @@ export const RecommendationList = ({ setNewNotification }) => {
     const [gameRecommendations, setGameRecommendations] = useState([])
     const [showRecommendations, setShowRecommendations] = useState([])
     const [bookRecommendations, setBookRecommendations] = useState([])
+    const [isLoading, setLoading] = useState(true)
 
     useEffect(
         () => {
             SocialRepo.getAllGameRecommendations().then(setGameRecommendations)
-            SocialRepo.getAllBookRecommendations().then(setBookRecommendations)
-            SocialRepo.getAllShowRecommendations().then(setShowRecommendations)
-            setNewNotification(false)
-            SocialRepo.readBookRecommendations()
-            SocialRepo.readGameRecommendations()
-            SocialRepo.readShowRecommendations()
+                .then(SocialRepo.readGameRecommendations)
+                .then(() => SocialRepo.getAllBookRecommendations().then(setBookRecommendations)
+                    .then(SocialRepo.readBookRecommendations))
+                .then(() => SocialRepo.getAllShowRecommendations().then(setShowRecommendations)
+                    .then(SocialRepo.readShowRecommendations))
+                .then(() => {
+                    setLoading(false)
+                    setNewNotification(false)
+                })
         }, []
     )
 
     return (
         <div className="row justify-content-center mt-5">
-            <div className="col-9">
-                {/* Full list of recommendation cards. Pass state of recommendation and the setter function to the individual recommendation card component */}
-                {
-                    gameRecommendations.length > 0 || showRecommendations.length > 0 || bookRecommendations.length > 0
-                        ? <div>
+            {
+                isLoading
+                    ? <div className="col-9"> </div>
+                    : <div className="col-9">
+                        {
+                            gameRecommendations.length > 0 || showRecommendations.length > 0 || bookRecommendations.length > 0
+                                ? <div>
 
-                            {gameRecommendations.map(recommendation => <GameRecommendation key={recommendation.id} gameRecommendation={recommendation} setGameRecommendations={setGameRecommendations} />)}
-                            {showRecommendations.map(recommendation => <ShowRecommendation key={recommendation.id} showRecommendation={recommendation} setShowRecommendations={setShowRecommendations} />)}
-                            {bookRecommendations.map(recommendation => <BookRecommendation key={recommendation.id} bookRecommendation={recommendation} setBookRecommendations={setBookRecommendations} />)}
+                                    {gameRecommendations.map(recommendation => <GameRecommendation key={recommendation.id} gameRecommendation={recommendation} setGameRecommendations={setGameRecommendations} />)}
+                                    {showRecommendations.map(recommendation => <ShowRecommendation key={recommendation.id} showRecommendation={recommendation} setShowRecommendations={setShowRecommendations} />)}
+                                    {bookRecommendations.map(recommendation => <BookRecommendation key={recommendation.id} bookRecommendation={recommendation} setBookRecommendations={setBookRecommendations} />)}
 
-                        </div>
-                        : <div
-                            className="mt-5 pt-5 border-0 d-flex align-items-center justify-content-center"
-                        >
-                            <h5 className="mt-5 pt-5 text-center text-muted">
-                                No Recommendations
-                            </h5>
-                        </div>
-                }
-            </div>
+                                </div>
+                                : <div
+                                    className="mt-5 pt-5 border-0 d-flex align-items-center justify-content-center"
+                                >
+                                    <h5 className="mt-5 pt-5 text-center text-muted">
+                                        No Recommendations
+                                    </h5>
+                                </div>
+                        }
+                    </div>
+            }
+
         </div>
     )
 }

--- a/src/components/TVShows/CurrentShowsView.js
+++ b/src/components/TVShows/CurrentShowsView.js
@@ -42,8 +42,7 @@ export const CurrentShowsView = () => {
                 setAttemptBoolean(false)
             }
 
-            setLoading(true)
-            ShowRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.streamingServiceId)
+            ShowRepo.getAll(filters.current, filters.tagArray, filters.nameSearch,  filters.streamingServiceId)
                 .then(setShows)
                 .then(() => setLoading(false))
 

--- a/src/components/TVShows/CurrentShowsView.js
+++ b/src/components/TVShows/CurrentShowsView.js
@@ -42,7 +42,8 @@ export const CurrentShowsView = () => {
                 setAttemptBoolean(false)
             }
 
-            ShowRepo.getAll(filters.current, filters.nameSearch, filters.streamingServiceId, filters.tagArray)
+            setLoading(true)
+            ShowRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.streamingServiceId)
                 .then(setShows)
                 .then(() => setLoading(false))
 

--- a/src/components/TVShows/SearchShows.js
+++ b/src/components/TVShows/SearchShows.js
@@ -6,11 +6,13 @@ import { TagRepo } from "../../repositories/TagRepo"
 export const SearchShows = ({ userEntries, setUserEntries }) => {
     const [tags, setTags] = useState([])
     const [streamingServices, setStreamingServices] = useState([])
+    const [isLoading, setLoading] = useState(true)
 
     useEffect(
         () => {
             TagRepo.getTagsOnShows().then(setTags)
-            ShowRepo.getAllStreamingServices().then(setStreamingServices)
+                .then(() => ShowRepo.getAllStreamingServices().then(setStreamingServices))
+                .then(() => setLoading(false))
         }, []
     )
 
@@ -24,95 +26,101 @@ export const SearchShows = ({ userEntries, setUserEntries }) => {
     }
 
     return (
-        <Form className="pb-2 mt-5 px-2 bg-secondary shadow-sm rounded text-white" inline>
+        <>
+            {
+                isLoading
+                    ? <div className="pb-2 mt-5 px-2"></div>
+                    : <Form className="pb-2 mt-5 px-2 bg-secondary shadow-sm rounded text-white" inline>
 
-            <h5 className="text-center py-3">Filters</h5>
+                        <h5 className="text-center py-3">Filters</h5>
 
-            <FormGroup>
-                <Label for="nameSearch">
-                    Search by Title
-                </Label>
-                <Input
-                    id="nameSearch"
-                    type="search"
-                    placeholder="Title contains..."
-                    value={userEntries.name}
-                    onChange={(event) => {
-                        const userEntriesCopy = { ...userEntries }
-                        userEntriesCopy.name = event.target.value
-                        setUserEntries(userEntriesCopy)
-                    }}
-                />
-            </FormGroup>
-            <FormGroup>
-                <Label for="platformSelect">
-                    Streaming Service
-                </Label>
-                <Input
-                    id="platformSelect"
-                    name="select"
-                    type="select"
-                    value={userEntries.service}
-                    onChange={(event) => {
-                        const userEntriesCopy = { ...userEntries }
-                        userEntriesCopy.service = event.target.value
-                        setUserEntries(userEntriesCopy)
-                    }}
-                >
-                    <option value="0"> Select one... </option>
-                    {
-                        streamingServices.map(service => {
-                            return <option key={service.id} value={service.id}>{service.service} </option>
-                        })
-                    }
+                        <FormGroup>
+                            <Label for="nameSearch">
+                                Search by Title
+                            </Label>
+                            <Input
+                                id="nameSearch"
+                                type="search"
+                                placeholder="Title contains..."
+                                value={userEntries.name}
+                                onChange={(event) => {
+                                    const userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy.name = event.target.value
+                                    setUserEntries(userEntriesCopy)
+                                }}
+                            />
+                        </FormGroup>
+                        <FormGroup>
+                            <Label for="platformSelect">
+                                Streaming Service
+                            </Label>
+                            <Input
+                                id="platformSelect"
+                                name="select"
+                                type="select"
+                                value={userEntries.service}
+                                onChange={(event) => {
+                                    const userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy.service = event.target.value
+                                    setUserEntries(userEntriesCopy)
+                                }}
+                            >
+                                <option value="0"> Select one... </option>
+                                {
+                                    streamingServices.map(service => {
+                                        return <option key={service.id} value={service.id}>{service.service} </option>
+                                    })
+                                }
 
-                </Input>
-            </FormGroup>
-            <FormGroup>
-                <Label>
-                    Tags
-                </Label>
-                <div>
-                    {
-                        tags.length > 0
-                            ? tags.map(tag => {
-                                return <Button
-                                    key={`tag--${tag.id}`}
-                                    active={userEntries.tags.has(tag.id) ? true : false}
-                                    color="checkbox"
-                                    style={{borderRadius: '20px' }}
-                                    outline
-                                    size="sm"
-                                    className="mx-1 my-2 text-white"
-                                    onClick={() => setTag(tag.id)}
-                                >
-                                    {tag.tag}
-                                </Button>
+                            </Input>
+                        </FormGroup>
+                        <FormGroup>
+                            <Label>
+                                Tags
+                            </Label>
+                            <div>
+                                {
+                                    tags.length > 0
+                                        ? tags.map(tag => {
+                                            return <Button
+                                                key={`tag--${tag.id}`}
+                                                active={userEntries.tags.has(tag.id) ? true : false}
+                                                color="checkbox"
+                                                style={{ borderRadius: '20px' }}
+                                                outline
+                                                size="sm"
+                                                className="mx-1 my-2 text-white"
+                                                onClick={() => setTag(tag.id)}
+                                            >
+                                                {tag.tag}
+                                            </Button>
 
-                            })
-                            : ""
-                    }
-                </div>
-            </FormGroup>
-            <FormGroup className='row justify-content-center'>
-                <Button
-                    onClick={() => {
-                        let userEntriesCopy = { ...userEntries }
-                        userEntriesCopy = {
-                            name: "",
-                            service: "0",
-                            tags: new Set()
-                        }
-                        setUserEntries(userEntriesCopy)
-                    }
-                    }
-                    color="info"
-                    className="col-sm-9 col-md-7 col-lg-5 mt-2"
-                    size="sm"
-                >
-                    Clear Filters
-                </Button>
-            </FormGroup>
-        </Form>
+                                        })
+                                        : ""
+                                }
+                            </div>
+                        </FormGroup>
+                        <FormGroup className='row justify-content-center'>
+                            <Button
+                                onClick={() => {
+                                    let userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy = {
+                                        name: "",
+                                        service: "0",
+                                        tags: new Set()
+                                    }
+                                    setUserEntries(userEntriesCopy)
+                                }
+                                }
+                                color="info"
+                                className="col-sm-9 col-md-7 col-lg-5 mt-2"
+                                size="sm"
+                            >
+                                Clear Filters
+                            </Button>
+                        </FormGroup>
+                    </Form>
+            }
+        </>
     )
 }

--- a/src/components/TVShows/Show.js
+++ b/src/components/TVShows/Show.js
@@ -19,11 +19,11 @@ export const Show = ({ show, setShows }) => {
     const deleteShow = (showId) => {
         if (show.current === true) {
             ShowRepo.delete(showId)
-                .then(() => ShowRepo.getAll(true)
+                .then(() => ShowRepo.getAll("True")
                     .then(setShows))
         } else {
             ShowRepo.delete(showId)
-                .then(() => ShowRepo.getAll(false)
+                .then(() => ShowRepo.getAll("False")
                     .then(setShows))
         }
     }

--- a/src/components/TVShows/ShowQueueView.js
+++ b/src/components/TVShows/ShowQueueView.js
@@ -42,8 +42,7 @@ export const ShowQueueView = () => {
                 setAttemptBoolean(false)
             }
 
-            setLoading(true)
-            ShowRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.streamingServiceId)
+            ShowRepo.getAll(filters.current, filters.tagArray, filters.nameSearch, filters.streamingServiceId)
                 .then(setShows)
                 .then(() => setLoading(false))
 

--- a/src/components/TVShows/ShowQueueView.js
+++ b/src/components/TVShows/ShowQueueView.js
@@ -42,7 +42,8 @@ export const ShowQueueView = () => {
                 setAttemptBoolean(false)
             }
 
-            ShowRepo.getAll(filters.current, filters.nameSearch, filters.streamingServiceId, filters.tagArray)
+            setLoading(true)
+            ShowRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.streamingServiceId)
                 .then(setShows)
                 .then(() => setLoading(false))
 

--- a/src/components/Tags/TagView.js
+++ b/src/components/Tags/TagView.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Card, FormGroup, Input, Label } from 'reactstrap';
+import { Button, FormGroup, Input, Label } from 'reactstrap';
 import { TagRepo } from '../../repositories/TagRepo';
 import { TagList } from './TagList';
 import { TagSearch } from './TagSearch';
@@ -57,41 +57,45 @@ export const TagView = () => {
     }
 
     return (
-
-        <div className="p-5 m-5 border gradient rounded">
-            <div className='row justify-content-center mb-3'>
-                <TagSearch setUserEntry={setUserEntry} userEntry={userEntry} />
-            </div>
+        <>
             {
                 isLoading
-                    ? < Card className="col-7 d-flex align-items-center justify-content-center border-0" />
-                    : <TagList tags={tags} setTags={setTags} userAttemptedSearch={userAttemptedSearch} setUserEntry={setUserEntry} />
-            }
-            <div className='row justify-content-center'>
-                {
-                    openBoolean
-                        ? <FormGroup className="col-5 mt-4">
-                            <Label>New Tag Name</Label>
-                            <Input
-                                id="tagEdit"
-                                type="text"
-                                onKeyUp={(event) => {
-                                    if (event.key === "Enter") {
-                                        constructTag(newTagString)
-                                    } else {
-                                        setNewTagString(event.target.value)
-                                    }
-                                }}
-                            />
-                            <div className='row justify-content-center'>
-                                <Button color="info" className="col-2 mt-4 px-1" onClick={() => constructTag(newTagString)}>Submit</Button>
-                            </div>
-                        </FormGroup>
+                    ? ""
+                    :
+                    <div className="p-5 m-5 border gradient rounded">
+                        <div className='row justify-content-center mb-3'>
+                            <TagSearch setUserEntry={setUserEntry} userEntry={userEntry} />
+                        </div>
 
-                        : <Button color="info" className="col-lg-2 col-md-3 col-sm-4 col-xs-5 mt-4 px-1 " onClick={() => setOpenBoolean(!openBoolean)}>Add A New Tag</Button>
-                }
-            </div>
-        </div>
+                        <TagList tags={tags} setTags={setTags} userAttemptedSearch={userAttemptedSearch} setUserEntry={setUserEntry} />
+
+                        <div className='row justify-content-center'>
+                            {
+                                openBoolean
+                                    ? <FormGroup className="col-5 mt-4">
+                                        <Label>New Tag Name</Label>
+                                        <Input
+                                            id="tagEdit"
+                                            type="text"
+                                            onKeyUp={(event) => {
+                                                if (event.key === "Enter") {
+                                                    constructTag(newTagString)
+                                                } else {
+                                                    setNewTagString(event.target.value)
+                                                }
+                                            }}
+                                        />
+                                        <div className='row justify-content-center'>
+                                            <Button color="info" className="col-2 mt-4 px-1" onClick={() => constructTag(newTagString)}>Submit</Button>
+                                        </div>
+                                    </FormGroup>
+
+                                    : <Button color="info" className="col-lg-2 col-md-3 col-sm-4 col-xs-5 mt-4 px-1 " onClick={() => setOpenBoolean(!openBoolean)}>Add A New Tag</Button>
+                            }
+                        </div>
+                    </div>
+            }
+        </>
 
     )
 }

--- a/src/components/VideoGames/CurrentGamesView.js
+++ b/src/components/VideoGames/CurrentGamesView.js
@@ -45,8 +45,7 @@ export const CurrentGamesView = () => {
                 setAttemptBoolean(false)
             }
 
-            setLoading(true)
-            GameRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.platformId, filters.multiplayer)
+            GameRepo.getAll( filters.current, filters.tagArray, filters.nameSearch, filters.platformId, filters.multiplayer)
                 .then(setGames)
                 .then(() => setLoading(false))
 

--- a/src/components/VideoGames/CurrentGamesView.js
+++ b/src/components/VideoGames/CurrentGamesView.js
@@ -13,7 +13,7 @@ export const CurrentGamesView = () => {
     const [userAttemptedSearch, setAttemptBoolean] = useState(false)
     const [userEntries, setUserEntries] = useState({
         name: "",
-        multiplayer: null,
+        multiplayer: "",
         platform: "0",
         tags: new Set()
     })
@@ -45,7 +45,8 @@ export const CurrentGamesView = () => {
                 setAttemptBoolean(false)
             }
 
-            GameRepo.getAll(filters.current, filters.nameSearch, filters.platformId, filters.multiplayer, filters.tagArray)
+            setLoading(true)
+            GameRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.platformId, filters.multiplayer)
                 .then(setGames)
                 .then(() => setLoading(false))
 

--- a/src/components/VideoGames/Game.js
+++ b/src/components/VideoGames/Game.js
@@ -21,11 +21,11 @@ export const Game = ({ game, showDetail, setGames }) => {
     const deleteGame = (gameId) => {
         if (game.current === true) {
             GameRepo.delete(gameId)
-                .then(() => GameRepo.getAll(true)
+                .then(() => GameRepo.getAll("True")
                     .then(setGames))
         } else {
             GameRepo.delete(gameId)
-                .then(() => GameRepo.getAll(false)
+                .then(() => GameRepo.getAll("False")
                     .then(setGames))
         }
     }

--- a/src/components/VideoGames/GameQueueView.js
+++ b/src/components/VideoGames/GameQueueView.js
@@ -45,7 +45,8 @@ export const GameQueueView = () => {
                 setAttemptBoolean(false)
             }
 
-            GameRepo.getAll(filters.current, filters.nameSearch, filters.platformId, filters.multiplayer, filters.tagArray)
+            setLoading(true)
+            GameRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.platformId, filters.multiplayer)
                 .then(setGames)
                 .then(() => setLoading(false))
 

--- a/src/components/VideoGames/GameQueueView.js
+++ b/src/components/VideoGames/GameQueueView.js
@@ -45,8 +45,7 @@ export const GameQueueView = () => {
                 setAttemptBoolean(false)
             }
 
-            setLoading(true)
-            GameRepo.getAll(filters.tagArray, filters.nameSearch, filters.current, filters.platformId, filters.multiplayer)
+            GameRepo.getAll( filters.current, filters.tagArray, filters.nameSearch,filters.platformId, filters.multiplayer)
                 .then(setGames)
                 .then(() => setLoading(false))
 

--- a/src/components/VideoGames/SearchGames.js
+++ b/src/components/VideoGames/SearchGames.js
@@ -119,7 +119,7 @@ export const SearchGames = ({ userEntries, setUserEntries, taggedGames }) => {
                         let userEntriesCopy = { ...userEntries }
                         userEntriesCopy = {
                             name: "",
-                            multiplayer: null,
+                            multiplayer: "",
                             platform: "0",
                             tags: new Set()
                         }

--- a/src/components/VideoGames/SearchGames.js
+++ b/src/components/VideoGames/SearchGames.js
@@ -3,14 +3,16 @@ import { Button, Form, FormGroup, Input, Label } from "reactstrap"
 import { GameRepo } from "../../repositories/GameRepo"
 import { TagRepo } from "../../repositories/TagRepo"
 
-export const SearchGames = ({ userEntries, setUserEntries, taggedGames }) => {
+export const SearchGames = ({ userEntries, setUserEntries }) => {
     const [platforms, setPlatforms] = useState([])
     const [tags, setTags] = useState([])
+    const [isLoading, setLoading] = useState(true)
 
     useEffect(
         () => {
             GameRepo.getAllPlatforms().then(setPlatforms)
-            TagRepo.getTagsOnGames().then(setTags)
+                .then(() => TagRepo.getTagsOnGames().then(setTags))
+                .then(() => setLoading(false))
         }, []
     )
 
@@ -25,114 +27,120 @@ export const SearchGames = ({ userEntries, setUserEntries, taggedGames }) => {
 
 
     return (
-        <Form className="pb-2 mt-5 px-2 bg-secondary shadow-sm rounded text-white" inline>
+        <>
+            {
+                isLoading
+                    ? <div className="pb-2 mt-5 px-2"></div>
+                    : <Form className="pb-2 mt-5 px-2 bg-secondary shadow-sm rounded text-white" inline>
 
-            <h5 className="text-center py-3">Filters</h5>
+                        <h5 className="text-center py-3">Filters</h5>
 
-            <FormGroup>
-                <Label for="nameSearch">
-                    Search by Title
-                </Label>
-                <Input
-                    id="nameSearch"
-                    type="search"
-                    placeholder="Title contains..."
-                    value={userEntries.name}
-                    onChange={(event) => {
-                        const userEntriesCopy = { ...userEntries }
-                        userEntriesCopy.name = event.target.value
-                        setUserEntries(userEntriesCopy)
-                    }}
-                />
-            </FormGroup>
-            <FormGroup>
-                <Label for="platformSelect">
-                    Platform
-                </Label>
-                <Input
-                    id="platformSelect"
-                    name="select"
-                    type="select"
-                    value={userEntries.platform}
-                    onChange={(event) => {
-                        const userEntriesCopy = { ...userEntries }
-                        userEntriesCopy.platform = event.target.value
-                        setUserEntries(userEntriesCopy)
-                    }}
-                >
-                    <option value="0"> Select one... </option>
-                    {platforms.map(platform => {
-                        return <option value={platform.id} key={platform.id}>{platform.name}</option>
-                    })}
-                </Input>
-            </FormGroup>
-            <FormGroup>
-                <Label for="multiplayerSelect">
-                    Multiplayer Capable
-                </Label>
-                <Input
-                    id="multiplayerSelect"
-                    name="select"
-                    type="select"
-                    value={userEntries.multiplayer}
-                    onChange={(event) => {
-                        const copy = { ...userEntries }
-                        copy.multiplayer = event.target.value
-                        setUserEntries(copy)
-                    }}
-                >
-                    <option value=""> Select one... </option>
-                    <option value="True"> Yes </option>
-                    <option value="False"> No </option>
+                        <FormGroup>
+                            <Label for="nameSearch">
+                                Search by Title
+                            </Label>
+                            <Input
+                                id="nameSearch"
+                                type="search"
+                                placeholder="Title contains..."
+                                value={userEntries.name}
+                                onChange={(event) => {
+                                    const userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy.name = event.target.value
+                                    setUserEntries(userEntriesCopy)
+                                }}
+                            />
+                        </FormGroup>
+                        <FormGroup>
+                            <Label for="platformSelect">
+                                Platform
+                            </Label>
+                            <Input
+                                id="platformSelect"
+                                name="select"
+                                type="select"
+                                value={userEntries.platform}
+                                onChange={(event) => {
+                                    const userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy.platform = event.target.value
+                                    setUserEntries(userEntriesCopy)
+                                }}
+                            >
+                                <option value="0"> Select one... </option>
+                                {platforms.map(platform => {
+                                    return <option value={platform.id} key={platform.id}>{platform.name}</option>
+                                })}
+                            </Input>
+                        </FormGroup>
+                        <FormGroup>
+                            <Label for="multiplayerSelect">
+                                Multiplayer Capable
+                            </Label>
+                            <Input
+                                id="multiplayerSelect"
+                                name="select"
+                                type="select"
+                                value={userEntries.multiplayer}
+                                onChange={(event) => {
+                                    const copy = { ...userEntries }
+                                    copy.multiplayer = event.target.value
+                                    setUserEntries(copy)
+                                }}
+                            >
+                                <option value=""> Select one... </option>
+                                <option value="True"> Yes </option>
+                                <option value="False"> No </option>
 
-                </Input>
-            </FormGroup>
-            <FormGroup >
-                <Label>
-                    Tags
-                </Label>
-                <div>
-                    {
-                        tags.length > 0
-                            ? tags.map(tag => {
-                                return <Button
-                                    key={`tag--${tag.id}`}
-                                    active={userEntries.tags.has(tag.id) ? true : false}
-                                    color="checkbox"
-                                    style={{borderRadius: '20px' }}
-                                    outline
-                                    size="sm"
-                                    className="mx-1 my-2 text-white"
-                                    onClick={() => setTag(tag.id)}
-                                >
-                                    {tag.tag}
-                                </Button>
+                            </Input>
+                        </FormGroup>
+                        <FormGroup >
+                            <Label>
+                                Tags
+                            </Label>
+                            <div>
+                                {
+                                    tags.length > 0
+                                        ? tags.map(tag => {
+                                            return <Button
+                                                key={`tag--${tag.id}`}
+                                                active={userEntries.tags.has(tag.id) ? true : false}
+                                                color="checkbox"
+                                                style={{ borderRadius: '20px' }}
+                                                outline
+                                                size="sm"
+                                                className="mx-1 my-2 text-white"
+                                                onClick={() => setTag(tag.id)}
+                                            >
+                                                {tag.tag}
+                                            </Button>
 
-                            })
-                            : ""
-                    }
-                </div>
-            </FormGroup>
-            <FormGroup className='row justify-content-center'>
-                <Button
-                    onClick={() => {
-                        let userEntriesCopy = { ...userEntries }
-                        userEntriesCopy = {
-                            name: "",
-                            multiplayer: "",
-                            platform: "0",
-                            tags: new Set()
-                        }
-                        setUserEntries(userEntriesCopy)
-                    }
-                    }
-                    color="info"
-                    size="sm"
-                    className="col-sm-9 col-md-7 col-lg-5 mt-2"
-                >
-                    Clear Filters
-                </Button>
-            </FormGroup>
-        </Form>
+                                        })
+                                        : ""
+                                }
+                            </div>
+                        </FormGroup>
+                        <FormGroup className='row justify-content-center'>
+                            <Button
+                                onClick={() => {
+                                    let userEntriesCopy = { ...userEntries }
+                                    userEntriesCopy = {
+                                        name: "",
+                                        multiplayer: "",
+                                        platform: "0",
+                                        tags: new Set()
+                                    }
+                                    setUserEntries(userEntriesCopy)
+                                }
+                                }
+                                color="info"
+                                size="sm"
+                                className="col-sm-9 col-md-7 col-lg-5 mt-2"
+                            >
+                                Clear Filters
+                            </Button>
+                        </FormGroup>
+                    </Form>
+            }
+        </>
     )
 }

--- a/src/repositories/BookRepo.js
+++ b/src/repositories/BookRepo.js
@@ -3,7 +3,7 @@ import { fetchIt } from "./FetchIt"
 //Object (BookRepo) with methods (functions) added onto it, making each function accessible via dot notation.
 export const BookRepo = {
     //GETs
-    async getAll(current = "", nameSearch = "", authorId = "", tags) {
+    async getAll(tags, nameSearch = "", current = "", authorId = "") {
         let tagString = ""
         if (tags) {
             for (const tagId of tags) {

--- a/src/repositories/BookRepo.js
+++ b/src/repositories/BookRepo.js
@@ -3,7 +3,7 @@ import { fetchIt } from "./FetchIt"
 //Object (BookRepo) with methods (functions) added onto it, making each function accessible via dot notation.
 export const BookRepo = {
     //GETs
-    async getAll(tags, nameSearch = "", current = "", authorId = "") {
+    async getAll(current = "", tags, nameSearch = "", authorId = "") {
         let tagString = ""
         if (tags) {
             for (const tagId of tags) {

--- a/src/repositories/GameRepo.js
+++ b/src/repositories/GameRepo.js
@@ -3,7 +3,7 @@ import { fetchIt } from "./FetchIt"
 //Object (GameRepo) with methods (functions) added onto it, making each function accessible via dot notation.
 export const GameRepo = {
     //GETs
-    async getAll(tags, nameSearch = "", current = "", platformId = "", multiplayer= "") {
+    async getAll(current = "", tags, nameSearch = "",  platformId = "", multiplayer= "") {
         let tagString = ""
         if (tags) {
             for (const tagId of tags) {

--- a/src/repositories/GameRepo.js
+++ b/src/repositories/GameRepo.js
@@ -3,7 +3,7 @@ import { fetchIt } from "./FetchIt"
 //Object (GameRepo) with methods (functions) added onto it, making each function accessible via dot notation.
 export const GameRepo = {
     //GETs
-    async getAll(current = "", nameSearch = "", platformId = "", multiplayer= "", tags) {
+    async getAll(tags, nameSearch = "", current = "", platformId = "", multiplayer= "") {
         let tagString = ""
         if (tags) {
             for (const tagId of tags) {

--- a/src/repositories/ShowRepo.js
+++ b/src/repositories/ShowRepo.js
@@ -3,7 +3,7 @@ import { fetchIt } from "./FetchIt"
 //Object (ShowRepo) with methods (functions) added onto it, making each function accessible via dot notation.
 export const ShowRepo = {
     //GETs
-    async getAll(tags, nameSearch = "", current="", streamingServiceId = "") {
+    async getAll(current="", tags, nameSearch = "",  streamingServiceId = "") {
         let tagString = ""
         if (tags) {
             for (const tagId of tags) {

--- a/src/repositories/ShowRepo.js
+++ b/src/repositories/ShowRepo.js
@@ -3,7 +3,7 @@ import { fetchIt } from "./FetchIt"
 //Object (ShowRepo) with methods (functions) added onto it, making each function accessible via dot notation.
 export const ShowRepo = {
     //GETs
-    async getAll(current = "", nameSearch = "", streamingServiceId = "", tags) {
+    async getAll(tags, nameSearch = "", current="", streamingServiceId = "") {
         let tagString = ""
         if (tags) {
             for (const tagId of tags) {


### PR DESCRIPTION
Cleaned up sorting/filtering on homepage, then reduced visuals of re-renders by setting loading states. 

Did a similar thing with all other lists with loading states.

Fixed a bug caused by the previous pull request that happened on game/show/book delete.